### PR TITLE
Remove all-synthetic from optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dev = [
 all = [
   "autora[all-theorists]",
   "autora[all-experimentalists]",
-  "autora[all-synthetic]",
   "autora[all-experiment-runners]",
 ]
 


### PR DESCRIPTION
`all-synthetic` removed from optional dependencies since `autora-synthetic` is listed in the deps above